### PR TITLE
Don't publish all files

### DIFF
--- a/bin/transfer_readtags.py
+++ b/bin/transfer_readtags.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+
+import argparse
+from pysam import AlignmentFile, AlignedSegment, AlignmentHeader
+from typing import Tuple
+from typing import List
+import random
+from itertools import groupby
+from argparse import ArgumentParser
+
+def iter_read_pairs(unaligned_bam: AlignmentFile, aligned_bam: AlignmentFile):
+    """
+    Assuming two lexsorted bam files, one unaligned and one aligned, iterates over the read pairs.
+    Assumes each file is only present once in the unaligned_bam but may be present multiple times in the aligned_bam.
+
+    Parameters
+    ----------
+    unaligned_bam: AlignmentFile
+        lexsorted unaligned bam file, each read name should only be present once
+    aligned_bam: AlignmentFile
+        lexsorted aligned bam file, reads can be present multiple times
+    """
+    grouped_ubam = groupby(unaligned_bam, lambda record: record.query_name)
+    grouped_bam = groupby(aligned_bam, lambda record: record.query_name)
+    for index, readpair in enumerate(zip(grouped_ubam, grouped_bam), start=1):
+        (ubam_read_name, ubam_reads_it), (bam_read_name, bam_reads_it) = readpair
+        ubam_reads = tuple(ubam_reads_it)
+        # it's assumed the files are lexsorted and contain the same readnames:
+        if ubam_read_name != bam_read_name:
+            raise ValueError(
+                f"read {index} has different names for ubam and bam:\nubam\n{ubam_read_name}\nbam\n{bam_read_name}"
+            )
+        if len(ubam_reads) > 1:
+            raise ValueError(
+                f"read {index} has multiple reads for ubam read name {ubam_read_name}"
+            )
+        ubam_read = ubam_reads[0]
+        for bam_read in bam_reads_it:
+            yield ubam_read, bam_read
+
+
+def transfer_read_tags(
+    source_read: AlignedSegment, target_read: AlignedSegment, tags: Tuple[str], primary_only_tags: Tuple[str]
+):
+    """
+    Copies a tag from the source_read
+    """
+    for tag in tags:
+        target_read.set_tag(tag, source_read.get_tag(tag))
+    if not (target_read.is_supplementary or target_read.is_secondary):
+        for tag in primary_only_tags:
+            target_read.set_tag(tag, source_read.get_tag(tag))
+    return target_read
+
+
+def transfer_read_groups(source_read: AlignedSegment, target_read: AlignedSegment):
+    """
+    Copies the read group from the source_read to the target_read
+    """
+    target_read.set_tag("RG", source_read.get_tag("RG"))
+    return target_read
+
+def append_pg_suffix(header: dict, suffix: str = "ubam") -> dict:
+    """
+    Appends a suffix to the PG field in the header.
+    """
+    if "PG" not in header:
+        return header
+    pg_field = header["PG"]
+    for pg in header["PG"]:
+        pg["ID"] = f"{pg['ID']}.{suffix}"
+        if 'PP' in pg:
+            pg["PP"] = f"{pg['PP']}.{suffix}"
+    header["PG"] = pg_field
+    return header
+
+def merge_headers(
+    source_bam: AlignmentFile, target_bam: AlignmentFile,
+    fields: Tuple[str] = ("RG", "PG")
+) -> AlignmentHeader:
+    """
+    Merges the headers of two BAM files.
+    """
+    source_header = source_bam.header.to_dict()
+    source_header = append_pg_suffix(source_header)
+    target_header = target_bam.header.to_dict()
+
+    # Add read groups from the source header to the merged header
+    for field in fields:
+        for element in source_header[field]:
+            if field not in target_header:
+                target_header[field] = []
+            target_header[field].append(element)
+
+    # Check for duplicate PG IDs
+    pg_ids = set()
+    for pg in target_header.get("PG", []):
+        if pg["ID"] in pg_ids:
+            raise ValueError(f"Duplicate PG ID found: {pg['ID']}")
+        pg_ids.add(pg["ID"])
+
+    return AlignmentHeader.from_dict(target_header)
+
+default_tags = [
+    "qs", # :f – Mean Phred Q-score for the read.
+    "ts", # :i – Samples trimmed from the start of the raw signal (noise at the pore open).
+    "ns", # :i – Index of the last sample kept (so ns − ts ≈ raw signal length used).
+    "mx", # :i – Mux group (0-3) that the pore/channel was assigned to.
+    "ch", # :i – Physical channel number on the flowcell.
+    "rn", # :i – Read number (counter that increments within each channel).
+    "st", # :Z – Read start time in ISO-8601 UTC.
+    "du", # :f – Read duration in seconds.
+    "fn", # :Z – Source POD5/FAST5 file name.
+    "sm", # :f - Signal-scaling midpoint (convert ADC units → pA).
+    "sd", # :f - Signal-scaling dispersion (convert ADC units → pA).
+    "sv", # :Z – Signal-scaling version (convert ADC units → pA).
+    "dx", # :i – Duplex flag (1 = duplex, 0 = simple).
+]
+
+default_primary_only_tags = [
+    "MM", # :Z – String that encodes every base modification in the read (e.g., 5-mC, 6-mA),
+          # giving the reference base, mod code and zero-based offsets along the read. 
+    "MN", # :i – Length of SEQ at the moment the MM/ML tags were written; if later clipping
+          # changes SEQ length, MM/ML are stale and MN will no longer match, acting as a sanity check. 
+    "ML", # :B:C – Byte array (0–255) of per-site probabilities that the corresponding
+          # modifications listed in MM are truly present, in the same order as they appear in MM. 
+]
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Transfer selected tags and read group from unaligned BAM to aligned BAM."
+    )
+    parser.add_argument("ubam", help="Path to the unmapped BAM file.")
+    parser.add_argument("aligned_bam", help="Path to the aligned BAM file.")
+    parser.add_argument("out_bam", help="Path to the output BAM file.")
+    parser.add_argument(
+        "--tags",
+        nargs="+",
+        default=default_tags,
+        help=f"Tags to transfer from unaligned to aligned BAM only for primary alignment (default: {default_tags}).",
+    )
+    parser.add_argument(
+        "--primary_only_tags",
+        nargs="+",
+        default=default_primary_only_tags,
+        help=f"Tags to transfer from unaligned to aligned BAM only for primary alignment (default: {default_primary_only_tags}).",
+    )
+
+    args = parser.parse_args()
+
+    print(f"UBAM file: {args.ubam}")
+    print(f"Aligned BAM file: {args.aligned_bam}")
+    print(f"Output BAM file: {args.out_bam}")
+    print(f"Tags to transfer: {args.tags}")
+    print(f"Tags to transfer to primary alignment only: {args.primary_only_tags}")
+    print("Processing BAM files...")
+
+    with (
+        AlignmentFile(args.ubam, "rb", check_sq=False, require_index=False) as ubam_handle,
+        AlignmentFile(args.aligned_bam, "rb", require_index=False) as bam_handle,
+    ):
+        out_header = merge_headers(ubam_handle, bam_handle)
+        with AlignmentFile(args.out_bam, "wb", header=out_header) as out_handle:
+            for ubam_read, bam_read in iter_read_pairs(ubam_handle, bam_handle):
+                read_with_tags = transfer_read_tags(ubam_read, bam_read, tags=args.tags, primary_only_tags=args.primary_only_tags)
+                read_with_rg_with_tags = transfer_read_groups(ubam_read, read_with_tags)
+                out_handle.write(read_with_rg_with_tags)
+
+
+if __name__ == "__main__":
+    main()

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -12,13 +12,6 @@
 
 process {
 
-    publishDir = [
-        path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
-        mode: 'copy',
-        enabled: true,
-        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-    ]
-
     // nanoseq.nf includes
     withName: CUSTOM_DUMPSOFTWAREVERSIONS {
         publishDir = [

--- a/modules/local/pysam_transfer_read_tags.nf
+++ b/modules/local/pysam_transfer_read_tags.nf
@@ -1,0 +1,27 @@
+process PYSAM_TRANSFER_READ_TAGS {
+    tag "$meta.id"
+    label 'process_medium'
+
+    container "quay.io/biocontainers/pysam:0.23.0--py311hb456a96_0"
+
+    input:
+    tuple val(meta), path(aligned_bam), path(tagged_bam)
+
+    output:
+    tuple val(meta), path("*tagged_aligned.bam"), emit: bam
+    path  "versions.yml", emit: versions
+
+    script:
+    """
+    transfer_readtags.py \\
+        $tagged_bam \\
+        $aligned_bam \\
+        ${meta.id}.tagged_aligned.bam
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        pysam: \$(python -c 'import pysam;print(pysam.__version__)')
+    END_VERSIONS
+    """
+}
+

--- a/modules/local/samtools_lexsort.nf
+++ b/modules/local/samtools_lexsort.nf
@@ -1,0 +1,23 @@
+process SAMTOOLS_LEXSORT {
+    tag "$meta.id"
+    label 'process_medium'
+
+    container "quay.io/biocontainers/samtools:1.21--h96c455f_1"
+
+    input:
+    tuple val(meta), path(bam)
+
+    output:
+    tuple val(meta), path("*lexsorted.bam"), emit: bam
+    path  "versions.yml", emit: versions
+
+    script:
+    """
+    samtools sort -N -@ $task.cpus -o ${bam.simpleName}.lexsorted.bam -T $meta.id $bam
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
+    END_VERSIONS
+    """
+}

--- a/modules/local/samtools_view_fastq.nf
+++ b/modules/local/samtools_view_fastq.nf
@@ -1,4 +1,4 @@
-process SAMTOOLS_VIEW_BAM {
+process SAMTOOLS_VIEW_FASTQ {
     tag "$meta.id"
     label 'process_medium'
 
@@ -8,15 +8,15 @@ process SAMTOOLS_VIEW_BAM {
         'quay.io/biocontainers/samtools:1.15.1--h1170115_0' }"
 
     input:
-    tuple val(meta), path(sam)
+    tuple val(meta), path(bam)
 
     output:
-    tuple val(meta), path("*.bam") ,emit: bam
-    path "versions.yml"        , emit: versions
+    tuple val(meta), path("*.fastq.gz"), emit: fastq
+    path "versions.yml", emit: versions
 
     script:
     """
-    samtools view -b -h -O BAM -@ $task.cpus -o ${meta.id}.bam $sam
+    samtools fastq $bam | gzip > ${meta.id}.fastq.gz
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
@@ -24,3 +24,4 @@ process SAMTOOLS_VIEW_BAM {
     END_VERSIONS
     """
 }
+

--- a/modules/nf-core/modules/fastqc/main.nf
+++ b/modules/nf-core/modules/fastqc/main.nf
@@ -2,10 +2,10 @@ process FASTQC {
     tag "$meta.id"
     label 'process_medium'
 
-    conda (params.enable_conda ? "bioconda::fastqc=0.11.9" : null)
+    conda "bioconda::fastqc=0.11.9"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
-        'quay.io/biocontainers/fastqc:0.11.9--0' }"
+        'https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0' :
+        'quay.io/biocontainers/fastqc:0.12.1--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(reads)
@@ -20,30 +20,22 @@ process FASTQC {
 
     script:
     def args = task.ext.args ?: ''
-    // Add soft-links to original FastQs for consistent naming in pipeline
     def prefix = task.ext.prefix ?: "${meta.id}"
-    if (meta.single_end) {
-        """
-        [ ! -f  ${prefix}.fastq.gz ] && ln -s $reads ${prefix}.fastq.gz
-        fastqc $args --threads $task.cpus ${prefix}.fastq.gz
+    // Make list of old name and new name pairs to use for renaming in the bash while loop
+    def old_new_pairs = reads instanceof Path || reads.size() == 1 ? [[ reads, "${prefix}.${reads.extension}" ]] : reads.withIndex().collect { entry, index -> [ entry, "${prefix}_${index + 1}.${entry.extension}" ] }
+    def rename_to = old_new_pairs*.join(' ').join(' ')
+    def renamed_files = old_new_pairs.collect{ old_name, new_name -> new_name }.join(' ')
+    """
+    printf "%s %s\\n" $rename_to | while read old_name new_name; do
+        [ -f "\${new_name}" ] || ln -s \$old_name \$new_name
+    done
+    fastqc $args --memory 10000 --threads $task.cpus $renamed_files
 
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            fastqc: \$( fastqc --version | sed -e "s/FastQC v//g" )
-        END_VERSIONS
-        """
-    } else {
-        """
-        [ ! -f  ${prefix}_1.fastq.gz ] && ln -s ${reads[0]} ${prefix}_1.fastq.gz
-        [ ! -f  ${prefix}_2.fastq.gz ] && ln -s ${reads[1]} ${prefix}_2.fastq.gz
-        fastqc $args --threads $task.cpus ${prefix}_1.fastq.gz ${prefix}_2.fastq.gz
-
-        cat <<-END_VERSIONS > versions.yml
-        "${task.process}":
-            fastqc: \$( fastqc --version | sed -e "s/FastQC v//g" )
-        END_VERSIONS
-        """
-    }
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        fastqc: \$( fastqc --version | sed -e "s/FastQC v//g" )
+    END_VERSIONS
+    """
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"

--- a/nextflow.config
+++ b/nextflow.config
@@ -45,6 +45,8 @@ params {
     stranded                   = false
     save_align_intermeds       = false
     skip_alignment             = false
+    realign                    = false
+    transfer_read_tags         = false
 
     // Options: DNA variant calling
     call_variants              = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -206,6 +206,16 @@
                     "type": "boolean",
                     "description": "Skip alignment and downstream processes.",
                     "fa_icon": "fas fa-fast-forward"
+                },
+                "realign": {
+                    "type": "boolean",
+                    "description": "Realign from fastq extracted from bam.",
+                    "fa_icon": "fas fa-fast-forward"
+                },
+                "transfer_read_tags": {
+                    "type": "boolean",
+                    "description": "Transfer methylation read tags from input bam to realigned bam.",
+                    "fa_icon": "fas fa-fast-forward"
                 }
             }
         },

--- a/subworkflows/local/bam_sort_index_samtools.nf
+++ b/subworkflows/local/bam_sort_index_samtools.nf
@@ -2,7 +2,6 @@
  * Sort, index BAM file and run samtools stats, flagstat and idxstats
  */
 
-include { SAMTOOLS_VIEW_BAM  } from '../../modules/local/samtools_view_bam'
 include { SAMTOOLS_SORT      } from '../../modules/nf-core/modules/samtools/sort/main'
 include { SAMTOOLS_INDEX     } from '../../modules/nf-core/modules/samtools/index/main'
 include { SAMTOOLS_SORT_INDEX } from '../../modules/local/samtools_sort_index'
@@ -10,7 +9,7 @@ include { BAM_STATS_SAMTOOLS } from '../../subworkflows/nf-core/bam_stats_samtoo
 
 workflow BAM_SORT_INDEX_SAMTOOLS {
     take:
-    ch_sam // channel: [ val(meta), [ bam ] ]
+    ch_bam // channel: [ val(meta), path(sizes), val(is_transcripts), path(bam) ]
     call_variants
     ch_fasta
 
@@ -18,18 +17,17 @@ workflow BAM_SORT_INDEX_SAMTOOLS {
     /*
      * Sam to bam conversion
      */
-    SAMTOOLS_VIEW_BAM  ( ch_sam )
     if ( call_variants ) {
-        SAMTOOLS_SORT_INDEX ( SAMTOOLS_VIEW_BAM.out.bam )
-        ch_sam
+        SAMTOOLS_SORT_INDEX ( ch_bam.map { it -> [ it[0], it[3] ] } )
+        ch_bam
             .join( SAMTOOLS_SORT_INDEX.out.bam_bai )
             .map { it -> [ it[0], it[1], it[2], it[4], it[5] ] }
             .set { sortbam }
         BAM_STATS_SAMTOOLS ( SAMTOOLS_SORT_INDEX.out.bam_bai, ch_fasta )
     } else {
-        SAMTOOLS_SORT      ( SAMTOOLS_VIEW_BAM.out.bam )
+        SAMTOOLS_SORT      ( ch_bam.map { it -> [ it[0], it[3] ] } )
         SAMTOOLS_INDEX     ( SAMTOOLS_SORT.out.bam )
-        ch_sam
+        ch_bam
             .join( SAMTOOLS_SORT.out.bam )
             .join( SAMTOOLS_INDEX.out.bai )
             .map { it -> [ it[0], it[1], it[2], it[4], it[5] ] }

--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -21,7 +21,7 @@ workflow INPUT_CHECK {
         .set { ch_sample }
 
     emit:
-    ch_sample // [ sample, barcode, fasta, gtf, is_transcripts, annotation_str ]
+    ch_sample // [ sample, barcode, fasta, gtf, is_transcripts, annotation_str, input_file, nanopolish_fast5 ]
 }
 
 // Function to resolve fasta and gtf file if using iGenomes

--- a/subworkflows/local/transfer_read_tags.nf
+++ b/subworkflows/local/transfer_read_tags.nf
@@ -1,0 +1,34 @@
+/*
+ * Transfer read tags from one BAM to another
+ */
+
+include { SAMTOOLS_LEXSORT as SAMTOOLS_LEXSORT_ALIGNED } from '../../modules/local/samtools_lexsort'
+include { SAMTOOLS_LEXSORT as SAMTOOLS_LEXSORT_TAGGED } from '../../modules/local/samtools_lexsort'
+include { PYSAM_TRANSFER_READ_TAGS } from '../../modules/local/pysam_transfer_read_tags'
+
+
+workflow TRANSFER_READ_TAGS{
+    take:
+    aligned_bam // channel: [ val(meta), path(aligned_bam) ]
+    tagged_bam // channel: [ val(meta), path(tagged_bam) ]
+
+    main:
+    ch_versions = Channel.empty()
+
+    sorted_aligned_bam = SAMTOOLS_LEXSORT_ALIGNED(aligned_bam).bam
+    ch_versions = ch_versions.mix(SAMTOOLS_LEXSORT_ALIGNED.out.versions)
+
+    sorted_tagged_bam = SAMTOOLS_LEXSORT_TAGGED(tagged_bam).bam
+    ch_versions = ch_versions.mix(SAMTOOLS_LEXSORT_TAGGED.out.versions)
+
+    bams_ch = sorted_aligned_bam.join(sorted_tagged_bam, by: [0])
+
+    tagged_bam = PYSAM_TRANSFER_READ_TAGS(bams_ch).bam
+    ch_versions = ch_versions.mix(PYSAM_TRANSFER_READ_TAGS.out.versions)
+
+    emit:
+    tagged_bam
+    ch_versions
+}
+
+

--- a/workflows/nanoseq.nf
+++ b/workflows/nanoseq.nf
@@ -127,7 +127,10 @@ include { QCAT                  } from '../modules/local/qcat'
 include { BAM_RENAME            } from '../modules/local/bam_rename'
 include { BAMBU                 } from '../modules/local/bambu'
 include { MULTIQC               } from '../modules/local/multiqc'
+include { SAMTOOLS_VIEW_BAM     } from '../modules/local/samtools_view_bam'
+include { SAMTOOLS_VIEW_FASTQ   } from '../modules/local/samtools_view_fastq'
 include { CHOPPER } from '../modules/local/chopper'
+
 /*
  * SUBWORKFLOW: Consisting of a mix of local and nf-core/modules
  */
@@ -147,6 +150,7 @@ include { QUANTIFY_STRINGTIE_FEATURECOUNTS } from '../subworkflows/local/quantif
 include { DIFFERENTIAL_DESEQ2_DEXSEQ       } from '../subworkflows/local/differential_deseq2_dexseq'
 include { RNA_MODIFICATION_XPORE_M6ANET    } from '../subworkflows/local/rna_modifications_xpore_m6anet'
 include { RNA_FUSIONS_JAFFAL               } from '../subworkflows/local/rna_fusions_jaffal'
+include { TRANSFER_READ_TAGS               } from '../subworkflows/local/transfer_read_tags'
 
 ////////////////////////////////////////////////////
 /* --    IMPORT NF-CORE MODULES/SUBWORKFLOWS   -- */
@@ -265,9 +269,23 @@ workflow NANOSEQ{
             ch_software_versions = ch_software_versions.mix(QCAT.out.versions.ifEmpty(null))
         } else {
             if (!params.skip_alignment) {
-                ch_sample
-                    .map { it -> if (it[6].toString().endsWith('.gz')) [ it[0], it[6], it[2], it[1], it[4], it[5] ] }
-                    .set { ch_fastq }
+                if (!params.realign) {
+                    ch_sample
+                        .map { it -> if (it[6].toString().endsWith('.gz')) [ it[0], it[6], it[2], it[1], it[4], it[5] ] }
+                        .set { ch_fastq }
+                } else {
+
+                    ch_sample
+                        .map { it -> if (it[6].toString().endsWith('.bam')) [ it[0], it[6] ] }
+                        .set { ch_sample_bam }
+                    SAMTOOLS_VIEW_FASTQ ( ch_sample_bam )
+                    ch_fastq = Channel.empty()
+                    SAMTOOLS_VIEW_FASTQ.out.fastq
+                        .join(ch_sample)
+                        .map { it -> [ it[0], it[1], it[3], it[2], it[5], it[6] ] }
+                        .set { ch_fastq }
+                    ch_software_versions = ch_software_versions.mix(SAMTOOLS_VIEW_FASTQ.out.versions.ifEmpty(null))
+                }
             } else {
                 ch_fastq = Channel.empty()
             }
@@ -377,10 +395,26 @@ workflow NANOSEQ{
             ch_software_versions = ch_software_versions.mix(ALIGN_GRAPHMAP2.out.graphmap2_version.first().ifEmpty(null))
         }
 
+        SAMTOOLS_VIEW_BAM ( ch_align_sam.map { it -> [ it[0], it[3] ] } )
+        SAMTOOLS_VIEW_BAM.out.bam
+            .join( ch_align_sam )
+            .map { it -> [ it[0], it[2], it[3], it[1] ]}
+            .set { ch_align_bam }
+        ch_software_versions = ch_software_versions.mix(SAMTOOLS_VIEW_BAM.out.versions.first().ifEmpty(null))
+
+        if (params.transfer_read_tags) {
+            TRANSFER_READ_TAGS( ch_align_bam.map { it -> [ it[0], it[3] ] }, ch_sample_bam )
+            TRANSFER_READ_TAGS.out.tagged_bam
+                .join( ch_align_bam )
+                .map { it -> [ it[0], it[2], it[3], it[1] ]}
+                .set { ch_align_bam }
+            ch_software_versions = ch_software_versions.mix(TRANSFER_READ_TAGS.out.ch_versions.first().ifEmpty(null))
+        }
+
         /*
         * SUBWORKFLOW: View, then  sort, and index bam files
         */
-        BAM_SORT_INDEX_SAMTOOLS ( ch_align_sam, params.call_variants, ch_fasta )
+        BAM_SORT_INDEX_SAMTOOLS ( ch_align_bam, params.call_variants, ch_fasta )
         ch_view_sortbam = BAM_SORT_INDEX_SAMTOOLS.out.sortbam
         ch_software_versions = ch_software_versions.mix(BAM_SORT_INDEX_SAMTOOLS.out.samtools_versions.first().ifEmpty(null))
         ch_samtools_multiqc  = BAM_SORT_INDEX_SAMTOOLS.out.sortbam_stats_multiqc.ifEmpty([])


### PR DESCRIPTION
# Aims
This PR removes unnecessary publishing of files that aren't actually used in downstream applications.  
The nanoseq app only cares about some of the outputted files, but this workflow outputs most of them.
## PR checklist
- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!